### PR TITLE
Beamer theme 'singapore' does not work on unix systems

### DIFF
--- a/doc/slidedemo.mdk
+++ b/doc/slidedemo.mdk
@@ -5,7 +5,7 @@ Author        : Daan Leijen
 Affiliation   : Microsoft Research
 Email         : daan@microsoft.com
 Reveal Theme  : solarized
-Beamer Theme  : singapore
+Beamer Theme  : Singapore
 Package       : pstricks
 Package       : pst-plot
 Math Embed    : 64


### PR DESCRIPTION
On unix systems, files are case sensitive. 

Therefore, the beamer theme should be Singapore instead of singapore.