### PR TITLE
Fix broken or deprecated links for reference doc and prettify.js

### DIFF
--- a/doc/reference.mdk
+++ b/doc/reference.mdk
@@ -57,7 +57,7 @@ Colorizer   : madoko
 
 ~MadokoNet  : before="[madoko.net]: " background-color=Gainsboro
 
-Script      : https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js
+Script      : https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js
 
 Copyright   : Copyright 2013, Daan Leijen, Microsoft Corporation.
 License     : This is free software; you can redistribute it and/or modify it under the
@@ -3530,8 +3530,8 @@ output, PDF output is still highlighted using Madoko.  To enable prettify,
 first include the Google script in the metadata (see Section [#sec-metadata]):
 
 ``` 
-Script: https://google-code-prettify.googlecode.com\
-        /svn/loader/run_prettify.js
+Script: https://cdn.rawgit.com/google/code-prettify\
+        /master/loader/run_prettify.js
 ```
 
 and add the `.prettyprint` class using attributes:
@@ -3547,7 +3547,7 @@ function hi() {
 Note that Madoko automatically disables static syntax highlighting in the HTML
 output if the `.prettyprint` class is present.
 
-[GPretty]: http://code.google.com/p/google-code-prettify
+[GPretty]: https://github.com/google/code-prettify
 
 
 ## Advanced styling in LaTeX  { #sec-latex-style }

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ effort in Madoko to make the LaTeX generation robust and customizable. This
 makes it possible to write high-quality articles using just Madoko and get
 both a high-quality print format (PDF) and a good looking HTML page.
 
-For more information look at the [Madoko manual](http://research.microsoft.com/en-us/um/people/daan/madoko/doc/reference.html)
+For more information look at the [Madoko manual](http://madoko.org/reference.html)
 
 Have fun,
 -- Daan


### PR DESCRIPTION
Two minor documentation issues: 

1. The [link to the Madoko reference in readme.md](http://research.microsoft.com/en-us/um/people/daan/madoko/doc/reference.html) is broken and points to the author's Microsoft homepage.

2. The links to the Prettify library in the Madoko reference refer to the Google Code hosting location for prettify. That location is shut down/in archival mode. The [readme on google code](https://code.google.com/archive/p/google-code-prettify/) refers users to GitHub. The GitHub page uses a different CDN than the one mentioned in the docs.  
Using the updated location for prettify.js will allow users following the instructions in the Madoko reference to get recent versions of prettify and to navigate to the correct location to view information about the library.